### PR TITLE
Fix LSUIElement in macOS bundle

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -34,10 +34,10 @@
 	<string>10.15</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSHighResolutionCapable</key>
-	<string>True</string>
-	<key>LSUIElement</key>
-	<string>1</string>
+        <key>NSHighResolutionCapable</key>
+        <true/>
+        <key>LSUIElement</key>
+        <true/>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Application requires access to save screenshots to your gallery</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -236,8 +236,9 @@ if (APPLE)
         MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
         MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION}
         MACOSX_BUNDLE_IDENTIFIER "org.flameshot.Flameshot"
-        MACOSX_BUNDLE_GUI_IDENTIFIER "org.flameshot.Flameshot" 
-    ) 
+        MACOSX_BUNDLE_GUI_IDENTIFIER "org.flameshot.Flameshot"
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/cmake/modules/MacOSXBundleInfo.plist.in"
+    )
     target_link_libraries(
             flameshot
             qhotkey


### PR DESCRIPTION
## Summary
- use boolean values in `MacOSXBundleInfo.plist.in`
- reference custom Info.plist in the macOS bundle

This ensures the macOS bundle hides the Dock icon correctly.

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687911d9b26083249208a5c264390923