### PR TITLE
Fix LSUIElement in macOS bundle

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -5,31 +5,31 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-       <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+       <string>flameshot</string>
 	<key>CFBundleGetInfoString</key>
-       <string>${MACOSX_BUNDLE_INFO_STRING}</string>
+       <string></string>
 	<key>CFBundleIconFile</key>
-       <string>${MACOSX_BUNDLE_ICON_FILE}</string>
+       <string>flameshot</string>
 	<key>CFBundleIdentifier</key>
-       <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+       <string>@MACOSX_BUNDLE_IDENTIFIER@</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-       <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+       <string>Flameshot</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-       <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+       <string></string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-       <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+       <string>@PROJECT_VERSION@</string>
 	<key>CFBundleLongVersionString</key>
-       <string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+       <string>@PROJECT_VERSION@</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-       <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+       <string></string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.15</string>
 	<key>NSPrincipalClass</key>

--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -5,39 +5,39 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>flameshot</string>
+       <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
 	<key>CFBundleGetInfoString</key>
-	<string></string>
+       <string>${MACOSX_BUNDLE_INFO_STRING}</string>
 	<key>CFBundleIconFile</key>
-	<string>flameshot</string>
+       <string>${MACOSX_BUNDLE_ICON_FILE}</string>
 	<key>CFBundleIdentifier</key>
-	<string>@MACOSX_BUNDLE_IDENTIFIER@</string>
+       <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Flameshot</string>
+       <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string></string>
+       <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>@PROJECT_VERSION@</string>
+       <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
 	<key>CFBundleLongVersionString</key>
-	<string>@PROJECT_VERSION@</string>
+       <string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string></string>
+       <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.15</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSHighResolutionCapable</key>
-	<string>True</string>
-	<key>LSUIElement</key>
-	<string>1</string>
+        <key>NSHighResolutionCapable</key>
+        <true/>
+        <key>LSUIElement</key>
+        <true/>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Application requires access to save screenshots to your gallery</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,8 +34,8 @@ if (APPLE)
             COMMAND bash "-c" "sips -z 32 32     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_16x16@2x.png"
             COMMAND bash "-c" "sips -z 32 32     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_32x32.png"
             COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_32x32@2x.png"
-            COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_64x64x.png"
-            COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_64x64@2.png"
+            COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_64x64.png"
+            COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_64x64@2x.png"
             COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_128x128.png"
             COMMAND bash "-c" "sips -z 256 256   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_128x128@2x.png"
             COMMAND bash "-c" "sips -z 256 256   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_256x256.png"
@@ -236,8 +236,9 @@ if (APPLE)
         MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
         MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION}
         MACOSX_BUNDLE_IDENTIFIER "org.flameshot.Flameshot"
-        MACOSX_BUNDLE_GUI_IDENTIFIER "org.flameshot.Flameshot" 
-    ) 
+        MACOSX_BUNDLE_GUI_IDENTIFIER "org.flameshot.Flameshot"
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/cmake/modules/MacOSXBundleInfo.plist.in"
+    )
     target_link_libraries(
             flameshot
             qhotkey

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,7 @@ if (APPLE)
     endif()
 
     if(EXISTS "${FLAMESHOT_ICNS}")
-        set(MACOSX_BUNDLE_ICON_FILE flameshot.icns)
+        set(MACOSX_BUNDLE_ICON_FILE flameshot)
         set(APP_ICON_MACOSX ${FLAMESHOT_ICNS})
         set_source_files_properties(${APP_ICON_MACOSX} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
         add_executable(flameshot MACOSX_BUNDLE main.cpp ${APP_ICON_MACOSX})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,45 +24,40 @@ if (APPLE)
     set(FLAMESHOT_ICONSET ${CMAKE_BINARY_DIR}/flameshot.iconset)
     set(FLAMESHOT_ICNS ${CMAKE_BINARY_DIR}/flameshot.icns)
 
-    # generate iconset
-    execute_process(
-            COMMAND bash "-c" "mkdir -p \"${FLAMESHOT_ICONSET}\""
-    )
+    find_program(SIPS_EXECUTABLE sips)
+    find_program(ICONUTIL_EXECUTABLE iconutil)
 
-    execute_process(
-            COMMAND bash "-c" "sips -z 16 16     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_16x16.png"
-            COMMAND bash "-c" "sips -z 32 32     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_16x16@2x.png"
-            COMMAND bash "-c" "sips -z 32 32     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_32x32.png"
-            COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_32x32@2x.png"
-            COMMAND bash "-c" "sips -z 64 64     \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_64x64.png"
-            COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome.png --out \"${FLAMESHOT_ICONSET}\"/icon_64x64@2x.png"
-            COMMAND bash "-c" "sips -z 128 128   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_128x128.png"
-            COMMAND bash "-c" "sips -z 256 256   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_128x128@2x.png"
-            COMMAND bash "-c" "sips -z 256 256   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_256x256.png"
-            COMMAND bash "-c" "sips -z 512 512   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_256x256@2x.png"
-            COMMAND bash "-c" "sips -z 512 512   \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_512x512.png"
-            COMMAND bash "-c" "sips -z 1024 1024 \"${CMAKE_SOURCE_DIR}\"/data/img/app/flameshot.monochrome-1024.png --out \"${FLAMESHOT_ICONSET}\"/icon_512x512@2x.png"
+    if(SIPS_EXECUTABLE AND ICONUTIL_EXECUTABLE)
+        execute_process(COMMAND bash "-c" "mkdir -p \"${FLAMESHOT_ICONSET}\"")
+        execute_process(
+            COMMAND ${SIPS_EXECUTABLE} -z 16 16     "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome.png" --out "${FLAMESHOT_ICONSET}/icon_16x16.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 32 32     "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome.png" --out "${FLAMESHOT_ICONSET}/icon_16x16@2x.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 32 32     "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome.png" --out "${FLAMESHOT_ICONSET}/icon_32x32.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 64 64     "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome.png" --out "${FLAMESHOT_ICONSET}/icon_32x32@2x.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 64 64     "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome.png" --out "${FLAMESHOT_ICONSET}/icon_64x64.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 128 128   "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome.png" --out "${FLAMESHOT_ICONSET}/icon_64x64@2x.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 128 128   "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome-1024.png" --out "${FLAMESHOT_ICONSET}/icon_128x128.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 256 256   "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome-1024.png" --out "${FLAMESHOT_ICONSET}/icon_128x128@2x.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 256 256   "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome-1024.png" --out "${FLAMESHOT_ICONSET}/icon_256x256.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 512 512   "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome-1024.png" --out "${FLAMESHOT_ICONSET}/icon_256x256@2x.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 512 512   "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome-1024.png" --out "${FLAMESHOT_ICONSET}/icon_512x512.png"
+            COMMAND ${SIPS_EXECUTABLE} -z 1024 1024 "${CMAKE_SOURCE_DIR}/data/img/app/flameshot.monochrome-1024.png" --out "${FLAMESHOT_ICONSET}/icon_512x512@2x.png"
 
-            COMMAND bash "-c" "iconutil -o \"${FLAMESHOT_ICNS}\" -c icns \"${FLAMESHOT_ICONSET}\""
-    )
+            COMMAND ${ICONUTIL_EXECUTABLE} -o "${FLAMESHOT_ICNS}" -c icns "${FLAMESHOT_ICONSET}"
+        )
+        execute_process(COMMAND bash "-c" "rm -R \"${FLAMESHOT_ICONSET}\"")
+    else()
+        message(WARNING "sips or iconutil not found; macOS bundle will use a default icon")
+    endif()
 
-    execute_process(
-        COMMAND bash "-c" "rm -R \"${FLAMESHOT_ICONSET}\""
-    )
-
-    execute_process(
-        # copy icon from cache generated on the localhost if generation on CI failed
-        COMMAND bash "-c" "[[ -r '\"${FLAMESHOT_ICNS}\"' ]] || cp \"${CMAKE_SOURCE_DIR}\"/packaging/macos/flameshot.icns \"${FLAMESHOT_ICNS}\""
-    )
-
-    # Set application icon
-    set(MACOSX_BUNDLE_ICON_FILE flameshot.icns)
-
-    # And this part tells CMake where to find and install the file itself
-    set(APP_ICON_MACOSX ${FLAMESHOT_ICNS})
-    set_source_files_properties(${APP_ICON_MACOSX} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
-
-    add_executable(flameshot MACOSX_BUNDLE main.cpp ${APP_ICON_MACOSX})
+    if(EXISTS "${FLAMESHOT_ICNS}")
+        set(MACOSX_BUNDLE_ICON_FILE flameshot.icns)
+        set(APP_ICON_MACOSX ${FLAMESHOT_ICNS})
+        set_source_files_properties(${APP_ICON_MACOSX} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+        add_executable(flameshot MACOSX_BUNDLE main.cpp ${APP_ICON_MACOSX})
+    else()
+        add_executable(flameshot MACOSX_BUNDLE main.cpp)
+    endif()
 else ()
     add_executable(flameshot)
 endif ()


### PR DESCRIPTION
## Summary
- use boolean values in `MacOSXBundleInfo.plist.in`
- reference custom Info.plist in the macOS bundle
- fix iconset generation so `.icns` builds correctly

## Testing
- `cmake -S . -B build` *(fails: could not fetch qtcolorwidgets due to network)*

------
https://chatgpt.com/codex/tasks/task_e_687911d9b26083249208a5c264390923